### PR TITLE
Standardize HTML section comment styles

### DIFF
--- a/src/history.html
+++ b/src/history.html
@@ -413,12 +413,13 @@
 </head>
 <body>
 
+  <!-- ── THEME TOGGLE ──────────────────────────────────────── -->
   <button id="theme-toggle" aria-label="Toggle light/dark mode">
     <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
     <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><line x1="12" y1="2" x2="12" y2="4"/><line x1="12" y1="20" x2="12" y2="22"/><line x1="2" y1="12" x2="4" y2="12"/><line x1="20" y1="12" x2="22" y2="12"/><line x1="4.93" y1="4.93" x2="6.34" y2="6.34"/><line x1="17.66" y1="17.66" x2="19.07" y2="19.07"/><line x1="4.93" y1="19.07" x2="6.34" y2="17.66"/><line x1="17.66" y1="6.34" x2="19.07" y2="4.93"/></svg>
   </button>
 
-  <!-- LIGHTBOX -->
+  <!-- ── LIGHTBOX ──────────────────────────────────────────── -->
   <div id="lightbox" role="dialog" aria-modal="true" aria-label="Version detail">
     <div class="lb-box">
       <button id="lb-close" aria-label="Close">✕</button>
@@ -434,11 +435,13 @@
     </div>
   </div>
 
+  <!-- ── HEADER ────────────────────────────────────────────── -->
   <header class="page-header">
     <h1 class="page-title">Design History</h1>
     <p class="page-sub">From WYSIWYG templates to handcrafted single page design. Powered by a custom-built Markdown CMS. A visual record of every major redesign.</p>
   </header>
 
+  <!-- ── TIMELINE ──────────────────────────────────────────── -->
   <main>
     <div class="timeline">
 
@@ -543,6 +546,7 @@
     </div>
   </main>
 
+  <!-- ── FOOTER ────────────────────────────────────────────── -->
   <footer class="page-footer">
     <a class="footer-link" href="/">
       <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/></svg>
@@ -550,6 +554,7 @@
     </a>
   </footer>
 
+  <!-- ── SCRIPTS ───────────────────────────────────────────── -->
   <script>
     (function() {
       var root = document.documentElement;

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -45,7 +45,7 @@
 </head>
 <body>
 
-  <!-- ═══════════════════════════════════════════ LANDING -->
+  <!-- ── LANDING ───────────────────────────────────────────── -->
   <section id="home">
     <main class="landing-inner">
       <div class="landing-photo">
@@ -84,7 +84,7 @@
     </main>
   </section>
 
-  <!-- ═══════════════════════════════════════════ RESUME -->
+  <!-- ── RESUME ────────────────────────────────────────────── -->
   <section id="resume">
     <div class="resume-header-wrap">
       <header class="resume-header">

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -217,6 +217,7 @@
     <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
     <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><line x1="12" y1="2" x2="12" y2="4"/><line x1="12" y1="20" x2="12" y2="22"/><line x1="2" y1="12" x2="4" y2="12"/><line x1="20" y1="12" x2="22" y2="12"/><line x1="4.93" y1="4.93" x2="6.34" y2="6.34"/><line x1="17.66" y1="17.66" x2="19.07" y2="19.07"/><line x1="4.93" y1="19.07" x2="6.34" y2="17.66"/><line x1="17.66" y1="6.34" x2="19.07" y2="4.93"/></svg>
   </button>
+
   <!-- ── SCRIPTS ───────────────────────────────────────────── -->
   <script>
     (function() {

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -212,10 +212,12 @@
     </div>
   </section>
 
+  <!-- ── THEME TOGGLE ──────────────────────────────────────── -->
   <button id="theme-toggle" aria-label="Toggle light/dark mode">
     <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
     <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><line x1="12" y1="2" x2="12" y2="4"/><line x1="12" y1="20" x2="12" y2="22"/><line x1="2" y1="12" x2="4" y2="12"/><line x1="20" y1="12" x2="22" y2="12"/><line x1="4.93" y1="4.93" x2="6.34" y2="6.34"/><line x1="17.66" y1="17.66" x2="19.07" y2="19.07"/><line x1="4.93" y1="19.07" x2="6.34" y2="17.66"/><line x1="17.66" y1="6.34" x2="19.07" y2="4.93"/></svg>
   </button>
+  <!-- ── SCRIPTS ───────────────────────────────────────────── -->
   <script>
     (function() {
       const sha = document.querySelector('meta[name="build-sha"]');


### PR DESCRIPTION
Standardizes all HTML body section markers across `index.template.html` and `history.html` to match the `<!-- ── LABEL ─── -->` style used throughout `main.css`, `pdf.css`, and `history.html` inline styles.

- Converts `<!-- ═══ LABEL -->` (double-line, right-anchored) to `<!-- ── LABEL ─── -->` (single-line, left-anchored) in `index.template.html`
- Adds missing `<!-- ── THEME TOGGLE -->`, `<!-- ── HEADER -->`, `<!-- ── TIMELINE -->`, `<!-- ── FOOTER -->`, and `<!-- ── SCRIPTS -->` markers to `history.html` body
- Fixes off-style `<!-- LIGHTBOX -->` to `<!-- ── LIGHTBOX ──... -->`
- Adds missing blank line before `<!-- ── SCRIPTS -->` in `index.template.html`
- All markers are 65 chars wide, consistently spaced (1 blank line before, 0 after)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMdJ8dbWKhiNq1GNJPQuhx)_