### PR TITLE
Add SLSA provenance attestation for build artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
+      attestations: write
 
     steps:
       - name: Checkout repository
@@ -79,6 +81,13 @@ jobs:
           cp -r assets public/
           cp src/history.html public/
           echo "✅ Synced files to public/ directory"
+
+      - name: Attest build artifacts
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be  # v2.4.0
+        with:
+          subject-path: |
+            public/index.html
+            public/resume.pdf
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd  # v3

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ resume.md pushed to main
 │  convert_resume.py        — generates index.html                    │
 │  generate_pdf_browser.py  — generates resume.pdf                    │
 │  generate_share_image.py  — generates OG share image                │
+│  attest-build-provenance  — signs SLSA provenance for artifacts     │
 │  Wrangler                 — deploys to Cloudflare Pages             │
 └─────────────────────────────────────────────────────────────────────┘
         ↓


### PR DESCRIPTION
## Summary
This PR adds build artifact attestation to the CI/CD pipeline using GitHub's `attest-build-provenance` action, enabling SLSA provenance signing for generated artifacts.

## Changes
- **GitHub Actions workflow**: Added `id-token: write` and `attestations: write` permissions to support the attestation action
- **Build attestation step**: Integrated `actions/attest-build-provenance@v2.4.0` to cryptographically sign provenance for `public/index.html` and `public/resume.pdf`
- **Documentation**: Updated README to document the attestation step in the build pipeline

## Implementation Details
- The attestation step runs after artifact generation but before deployment to Cloudflare Pages
- Attestations are created for the two primary build outputs: the generated HTML resume and PDF resume
- Uses pinned action version (v2.4.0) with specific commit hash for reproducibility
- Required permissions (`id-token` and `attestations`) are scoped to the build job only

https://claude.ai/code/session_01RuV381r5oMw8qTKzMv1RDF