### PR TITLE
fix: bump pypdf to 6.13.3 to resolve GHSA-jm82-fx9c-mx94

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ pip-audit==2.10.1
 pre-commit==4.6.0
 ruff==0.15.17
 playwright==1.60.0
-pypdf==6.13.2
+pypdf==6.13.3
 pytest==9.1.0


### PR DESCRIPTION
Bumps `pypdf` from 6.13.2 to 6.13.3 to resolve `GHSA-jm82-fx9c-mx94`, flagged by `pip-audit` in the nightly job.

All 95 tests pass, `pip-audit` reports clean locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpKqwAhsbtZJSQJtFSjE4s)_